### PR TITLE
Fix CPU benchmark

### DIFF
--- a/hosting_benchmark/server/api/cpu.php
+++ b/hosting_benchmark/server/api/cpu.php
@@ -13,7 +13,7 @@ $results = array(
 
 function testMath(&$results, $count = 99999) {
     $mathFunctions = array(
-        "abs", "acos", "asin", "atan", "bindec", "floor", "exp", "sin", "tan",
+        "abs", "acos", "asin", "atan", "decbin", "floor", "exp", "sin", "tan",
         "pi", "is_finite", "is_nan", "sqrt",
     );
     $timeStart = microtime(true);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/samupl/hosting-benchmark/pulls) for the same update/change?

### Description
In PHP 7.4 passing invalid characters will now generate a deprecation notice.

This is because we don't have how to convert a binary number to a decimal by passing a decimal number to the function. I believe it was a mistake. That's why I corrected the function that converts a decimal number to a binary number.

https://www.php.net/manual/en/function.bindec.php#refsect1-function.bindec-changelog

### Motivation and Context
You will not receive an error when used with future PHP versions.

### How Has This Been Tested?
Run full script normally.
